### PR TITLE
Suppress compiler warning in resizedImageWithContentMode

### DIFF
--- a/UIImage+Resize.m
+++ b/UIImage+Resize.m
@@ -92,7 +92,7 @@
             break;
             
         default:
-            [NSException raise:NSInvalidArgumentException format:@"Unsupported content mode: %d", contentMode];
+            [NSException raise:NSInvalidArgumentException format:@"Unsupported content mode: %ld", (long)contentMode];
     }
     
     CGSize newSize = CGSizeMake(self.size.width * ratio, self.size.height * ratio);


### PR DESCRIPTION
An NSInteger is actually a long, so this change removes the compiler warning.